### PR TITLE
set ommsync=True

### DIFF
--- a/attach.py
+++ b/attach.py
@@ -18,6 +18,6 @@ omm_username = config['DEFAULT'].get('omm_username', 'omm')
 omm_password = config['DEFAULT'].get('omm_password')
 
 client = OMMClient(omm_ip, omm_port)
-client.login(omm_username, omm_password)
+client.login(omm_username, omm_password, ommsync=True)
 
 print('success' if client.attach_user_device(int(sys.argv[1], 0), int(sys.argv[2], 0)) else 'failure')

--- a/autoattach.py
+++ b/autoattach.py
@@ -20,7 +20,7 @@ omm_username = config['DEFAULT'].get('omm_username', 'omm')
 omm_password = config['DEFAULT'].get('omm_password')
 
 client = OMMClient(omm_ip, omm_port)
-client.login(omm_username, omm_password)
+client.login(omm_username, omm_password, ommsync=True)
 
 ub_users = list(client.find_users({'ppn': '0'}))
 print('Unbound users:', [u.num + ' (' + u.uid + ')' for u in ub_users])


### PR DESCRIPTION
I tried to use the scripts and they didn't work until i set ommsync=True at the omm login. This is according to https://github.com/dect-e/python-mitel/blob/master/OMMClient/OMMClient.py , ln.112 ...119:

> The normal OMPClient login is restricted
>         to all operations which can be performed using the OMP client application.
>         Using the OMM sync flag you will be able to perform further operations.
>         These operations are:
>             * Attach user profile to device (Login)
>             * Detach user profile from device (Logout)
>             * Write extended device information (read only in OMP)